### PR TITLE
Tomato class accepts emoji flag, add input arguments parsing

### DIFF
--- a/pydoro/pydoro_core/tomato.py
+++ b/pydoro/pydoro_core/tomato.py
@@ -428,9 +428,11 @@ class LongBreakPausedState(SmallBreakPausedState):
 
 
 class Tomato:
-    def __init__(self):
+    def __init__(self, emoji):
         self._state = InitialState(tomato=self)
         self.tomatoes = 0
+
+        self._emoji = emoji
 
     def start(self):
         self._state = self._state.start()
@@ -450,11 +452,14 @@ class Tomato:
             self._state = self._state.next_state
 
     def tomato_symbol(self):
-        try:
-            '🍅'.encode(sys.stdout.encoding)
-            return '🍅 '
-        except UnicodeEncodeError:
-            return '(`) '
+        ascii_tomato = '(`) '
+        if self._emoji:
+            try:
+                '🍅'.encode(sys.stdout.encoding)
+                return '🍅 '
+            except UnicodeEncodeError:
+                return ascii_tomato
+        return ascii_tomato
 
     def as_formatted_text(self):
         task = TEXT[self._state.task]

--- a/pydoro/pydoro_tui.py
+++ b/pydoro/pydoro_tui.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import threading
 
 from prompt_toolkit.application import Application
@@ -13,7 +14,14 @@ from pydoro.pydoro_core.tomato import Tomato
 from pydoro.pydoro_core.util import every
 from pydoro.pydoro_core.config import DEFAULT_KEY_BINDINGS
 
-tomato = Tomato()
+parser = argparse.ArgumentParser('pydoro')
+parser.add_argument(
+    '-e', '--emoji', action='store_true', default=False,
+    help="If set, use tomato emojis in the menu instead of the ASCII art"
+)
+args = parser.parse_args()
+
+tomato = Tomato(args.emoji)
 
 
 def exit_clicked(_=None):


### PR DESCRIPTION
Solves the issue #45. Let me know if you'd like to organize the input arguments parsing differently, or the way the flag is passed to the `Tomato` class :slightly_smiling_face:.