### PR TITLE
Refactor configurations (work in progress)

### DIFF
--- a/pydoro/pydoro_core/config.py
+++ b/pydoro/pydoro_core/config.py
@@ -2,11 +2,7 @@ import argparse
 import configparser
 import os
 
-
 from prompt_toolkit.key_binding import KeyBindings
-
-
-SECONDS_PER_MIN = 60
 
 
 class Configuration():
@@ -109,6 +105,17 @@ class Configuration():
             keys = keys.split(',')
             for key in keys:
                 self.kb.add(key.strip())(actions[action])
+
+        self.tomatoes_per_set =
+            int(self.conf['Time']['tomatoes_per_set'])
+        self.work_minutes =
+            int(self._conf['Time']['work_minutes'])
+        self.small_break_minutes =
+            int(self._conf['Time']['small_break_minutes'])
+        self.long_break_minutes =
+            int(self._conf['Time']['long_break_minutes'])
+        self.alarm_seconds =
+            int(self._conf['Time']['alarm_seconds'])
 
     def _cliload(self):
         """

--- a/pydoro/pydoro_core/config.py
+++ b/pydoro/pydoro_core/config.py
@@ -6,6 +6,9 @@ import os
 from prompt_toolkit.key_binding import KeyBindings
 
 
+SECONDS_PER_MIN = 60
+
+
 class Configuration():
     def __init__(self):
         self._cliparse() # Parse arguments from command line
@@ -68,9 +71,11 @@ class Configuration():
         self._conf['General']['emoji'] = 'False'
 
         self._conf['Time'] = {}
+        self._conf['Time']['tomatoes_per_set'] = '4'
         self._conf['Time']['work_minutes'] = '25'
         self._conf['Time']['small_break_minutes'] = '5'
         self._conf['Time']['long_break_minutes'] = '15'
+        self._conf['Time']['alarm_seconds'] = '20'
 
         self._conf['KeyBindings'] = {}
         self._conf['KeyBindings']['focus_previous'] = "s-tab,left,h,j"

--- a/pydoro/pydoro_core/config.py
+++ b/pydoro/pydoro_core/config.py
@@ -1,0 +1,3 @@
+class Configurations():
+    def __init__(self):
+        pass

--- a/pydoro/pydoro_core/config.py
+++ b/pydoro/pydoro_core/config.py
@@ -1,3 +1,124 @@
-class Configurations():
+import argparse
+import configparser
+import os
+
+
+from prompt_toolkit.key_binding import KeyBindings
+
+
+class Configuration():
     def __init__(self):
-        pass
+        self._cliparse() # Parse arguments from command line
+        self._iniparse() # Parse config (.ini) file
+        self.kb = KeyBindings()
+
+        # Load parsed configs (cli overrites ini)
+        self._iniload()
+        self._cliload()
+
+    def _cliparse(self):
+        """
+        Parse configurations from command line arguments
+        """
+        parser = argparse.ArgumentParser("pydoro", description="Terminal Pomodoro Timer")
+        parser.add_argument(
+            "-e",
+            "--emoji",
+            action="store_true",
+            help="If set, use tomato emoji instead of the ASCII art",
+        )
+        parser.add_argument(
+            "--focus",
+            help="focus mode: hides clock and \
+                            mutes sounds (equivalent to --no-clock and --no-sound)",
+            action="store_true",
+        )
+        parser.add_argument("--no-clock", help="hides clock", action="store_true")
+        parser.add_argument("--no-sound", help="mutes all sounds", action="store_true")
+        self.cliargs = parser.parse_args()
+
+    def _iniparse(self):
+        """
+        Look at PYDORO_CONFIG_FILE environment variable
+        Defaults to ~/.pydoro.ini if PYDORO_CONFIG_FILE not set
+        """
+        self._conf = configparser.ConfigParser()
+
+        filename = os.path.expanduser("~/.pydoro.ini")
+
+        if 'PYDORO_CONFIG_FILE' in os.environ:
+            filename = os.environ['PYDORO_CONFIG_FILE']
+
+        if os.path.exists(filename):
+            self._conf.read(filename)
+        else:
+            print("Couldn't read config file. Creating it (" + filename + ")")
+            self._create_default_ini()
+
+    def _create_default_ini(self):
+        """
+        Creates default ini configuration file
+        Saves it in '~/.pydoro.ini'
+        """
+        self._conf['DEFAULT'] = {}
+
+        self._conf['General'] = {}
+        self._conf['General']['no_clock'] = 'False'
+        self._conf['General']['no_sound'] = 'False'
+        self._conf['General']['emoji'] = 'False'
+
+        self._conf['Time'] = {}
+        self._conf['Time']['work_minutes'] = '25'
+        self._conf['Time']['small_break_minutes'] = '5'
+        self._conf['Time']['long_break_minutes'] = '15'
+
+        self._conf['KeyBindings'] = {}
+        self._conf['KeyBindings']['focus_previous'] = "s-tab,left,h,j"
+        self._conf['KeyBindings']['focus_next'] = "tab,right,l,k"
+        self._conf['KeyBindings']['exit_clicked'] = "q"
+
+        # Write file
+        filename = os.path.expanduser("~/.pydoro.ini")
+        with open(filename, "w+") as configfile:
+            self._conf.write(configfile)
+
+    def _iniload(self):
+        """
+        Loads the .ini config file preferences
+
+        Command line arguments override file configurations.
+        """
+
+        # Check for no-clock (or focus mode)
+        self.no_clock = self._conf['General']['no_clock'] == 'True'
+
+        # Check for no-sound (or focus mode)
+        self.no_sound = self._conf['General']['no_sound'] == 'True'
+
+        # Check for emoji
+        self.emoji = self._conf['General']['emoji'] == 'True'
+
+        # Load key bindings
+        for action, keys in self._conf['KeyBindings'].items():
+            # Split string from config file back into list
+            keys = keys.split(',')
+            for key in keys:
+                self.kb.add(key.strip())(actions[action])
+
+    def _cliload(self):
+        """
+        Loads the command line arguments
+
+        Command line arguments override file configurations.
+        """
+
+        # Check for no-clock (or focus mode)
+        self.no_clock = self.cliargs.no_clock or self.cliargs.focus
+
+        # Check for no-sound (or focus mode)
+        self.no_sound = self.cliargs.no_sound or self.cliargs.focus
+
+        # Check for emoji
+        self.emoji = cliargs.emoji
+
+

--- a/pydoro/pydoro_core/config.py
+++ b/pydoro/pydoro_core/config.py
@@ -104,17 +104,17 @@ class Configuration():
             # Split string from config file back into list
             keys = keys.split(',')
             for key in keys:
-                self.kb.add(key.strip())(actions[action])
+                self.kb.add(key.strip())(action)
 
-        self.tomatoes_per_set =
-            int(self.conf['Time']['tomatoes_per_set'])
-        self.work_minutes =
+        self.tomatoes_per_set = \
+            int(self._conf['Time']['tomatoes_per_set'])
+        self.work_minutes = \
             int(self._conf['Time']['work_minutes'])
-        self.small_break_minutes =
+        self.small_break_minutes = \
             int(self._conf['Time']['small_break_minutes'])
-        self.long_break_minutes =
+        self.long_break_minutes = \
             int(self._conf['Time']['long_break_minutes'])
-        self.alarm_seconds =
+        self.alarm_seconds = \
             int(self._conf['Time']['alarm_seconds'])
 
     def _cliload(self):
@@ -131,6 +131,6 @@ class Configuration():
         self.no_sound = self.cliargs.no_sound or self.cliargs.focus
 
         # Check for emoji
-        self.emoji = cliargs.emoji
+        self.emoji = self.cliargs.emoji
 
 

--- a/pydoro/pydoro_core/tomato.py
+++ b/pydoro/pydoro_core/tomato.py
@@ -5,6 +5,7 @@ from timeit import default_timer
 
 from pydoro.pydoro_core import sound
 from pydoro.pydoro_core.util import in_app_path
+import configs
 
 TOMATOES_PER_SET = 4
 SECONDS_PER_MIN = 60
@@ -421,11 +422,10 @@ class LongBreakPausedState(SmallBreakPausedState):
 
 
 class Tomato:
-    def __init__(self):
+    def __init__(self, configs=config.Configuration()):
+        # Load configurations from command line and .ini file
+        self.configs = configs
         self._state = InitialState(tomato=self)
-        self.no_clock = False
-        self.no_sound = False
-        self.emoji = False
         self.tomatoes = 0
 
     def start(self):

--- a/pydoro/pydoro_core/tomato.py
+++ b/pydoro/pydoro_core/tomato.py
@@ -7,6 +7,7 @@ from pydoro.pydoro_core import sound
 from pydoro.pydoro_core.util import in_app_path
 from pydoro.pydoro_core.configs import Configuration
 
+SECONDS_PER_MIN = 60
 
 PLACEHOLDER_TIME = "time"
 PLACEHOLDER_STATUS = "status"
@@ -227,7 +228,7 @@ class IntermediateState(InitialState):
         self._sound()
 
     def _sound(self):
-        if cur_time() - self._last_alarm_time > ALARM_TIME:
+        if cur_time() - self._last_alarm_time > self._tomato.configs.alarm_seconds:
             self._tomato.play_alarm()
             self._last_alarm_time = cur_time()
 
@@ -253,9 +254,10 @@ class IntermediateState(InitialState):
 class WorkingState(InitialState):
     name = "work"
 
-    def __init__(self, time_period=WORK_TIME, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
-        self._remainder = int(self._time_period)
+    def __init__(self, tomato=None):
+        super().__init__(tomato=tomato)
+        self._remainder =
+            int(self._tomato.configs.work_minutes)
         self._task = Tasks.WORK
         self._status = TaskStatus.STARTED
         self._started_at = cur_time()
@@ -273,7 +275,7 @@ class WorkingState(InitialState):
     @property
     def next_state(self):
         self._tomato.tomatoes += 1
-        if self._tomato.tomatoes % TOMATOES_PER_SET == 0:
+        if self._tomato.tomatoes % self.tomatoes_per_set == 0:
             return IntermediateState.transition_to(LongBreakState, tomato=self._tomato)
         return IntermediateState.transition_to(SmallBreakState, tomato=self._tomato)
 
@@ -292,8 +294,8 @@ class WorkingState(InitialState):
 class WorkPausedState(InitialState):
     name = "work paused"
 
-    def __init__(self, time_period=0, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
+    def __init__(self, tomato=None):
+        super().__init__(tomato=tomato)
         self._prev = None
         self._task = Tasks.WORK
         self._status = TaskStatus.PAUSED
@@ -324,9 +326,10 @@ class WorkPausedState(InitialState):
 class SmallBreakState(InitialState):
     name = "small break"
 
-    def __init__(self, time_period=SMALL_BREAK_TIME, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
-        self._remainder = int(self._time_period)
+    def __init__(self, tomato=None):
+        super().__init__(tomato=tomato)
+        self._remainder =
+            self._tomato.configs.small_break_minutes)
         self._task = Tasks.SMALL_BREAK
         self._status = TaskStatus.STARTED
         self._started_at = cur_time()
@@ -391,8 +394,8 @@ class SmallBreakPausedState(InitialState):
 class LongBreakState(SmallBreakState):
     name = "long break"
 
-    def __init__(self, time_period=LONG_BREAK_TIME, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
+    def __init__(self,tomato=None):
+        super().__init__(tomato=tomato)
         self._task = Tasks.LONG_BREAK
         self._status = TaskStatus.STARTED
 
@@ -464,7 +467,7 @@ class Tomato:
         if not task:
             task = [""] * 4
 
-        sets = self.tomatoes // TOMATOES_PER_SET
+        sets = self.tomatoes // self.tomatoes_per_set
         if sets == 1:
             sets = "1 set completed"
         elif sets >= 2:
@@ -475,7 +478,7 @@ class Tomato:
         status = TEXT[self._state.status]
         time = self._state.time_remaining
         count = self.tomato_symbol() * (
-            TOMATOES_PER_SET - self.tomatoes % TOMATOES_PER_SET
+            self.tomatoes_per_set - self.tomatoes % self.tomatoes_per_set
         )
 
         ftext = TOMATO[:]

--- a/pydoro/pydoro_core/tomato.py
+++ b/pydoro/pydoro_core/tomato.py
@@ -154,9 +154,9 @@ def cur_time():
 class InitialState:
     name = "initial"
 
-    def __init__(self, time_period=0, tomato=None):
-        self._time_period = int(time_period)
+    def __init__(self, tomato):
         self._tomato = tomato
+        self._time_period = int(time_period) # TODO: use time period from tomato configs
         self._task = Tasks.NO_TASK
         self._status = TaskStatus.NONE
         self._started_at = 0
@@ -165,7 +165,7 @@ class InitialState:
 
     def start(self):
         self._tomato.play_alarm()
-        return WorkingState(tomato=self._tomato)
+        return WorkingState(self._tomato)
 
     def pause(self):
         return self
@@ -219,8 +219,8 @@ class InitialState:
 class IntermediateState(InitialState):
     name = "waiting"
 
-    def __init__(self, time_period=0, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
+    def __init__(self, tomato):
+        super().__init__(tomato)
         self._task = Tasks.INTERMEDIATE
         self._status = TaskStatus.LIMBO
         self._next_factory = None
@@ -233,7 +233,7 @@ class IntermediateState(InitialState):
             self._last_alarm_time = cur_time()
 
     def start(self):
-        return self._next_factory(tomato=self._tomato)
+        return self._next_factory(self._tomato)
 
     @property
     def time_remaining(self):
@@ -246,7 +246,7 @@ class IntermediateState(InitialState):
 
     @staticmethod
     def transition_to(next_state_factory, tomato):
-        state = IntermediateState(tomato=tomato)
+        state = IntermediateState(tomato)
         state._next_factory = next_state_factory
         return state
 
@@ -254,8 +254,8 @@ class IntermediateState(InitialState):
 class WorkingState(InitialState):
     name = "work"
 
-    def __init__(self, tomato=None):
-        super().__init__(tomato=tomato)
+    def __init__(self, tomato):
+        super().__init__(tomato)
         self._remainder =
             int(self._tomato.configs.work_minutes)
         self._task = Tasks.WORK
@@ -276,8 +276,8 @@ class WorkingState(InitialState):
     def next_state(self):
         self._tomato.tomatoes += 1
         if self._tomato.tomatoes % self.tomatoes_per_set == 0:
-            return IntermediateState.transition_to(LongBreakState, tomato=self._tomato)
-        return IntermediateState.transition_to(SmallBreakState, tomato=self._tomato)
+            return IntermediateState.transition_to(LongBreakState, self._tomato)
+        return IntermediateState.transition_to(SmallBreakState, self._tomato)
 
     def pause(self):
         return WorkPausedState.return_to(self._tomato, self)
@@ -294,8 +294,8 @@ class WorkingState(InitialState):
 class WorkPausedState(InitialState):
     name = "work paused"
 
-    def __init__(self, tomato=None):
-        super().__init__(tomato=tomato)
+    def __init__(self, tomato):
+        super().__init__(tomato)
         self._prev = None
         self._task = Tasks.WORK
         self._status = TaskStatus.PAUSED
@@ -314,7 +314,7 @@ class WorkPausedState(InitialState):
 
     @staticmethod
     def return_to(tomato, state):
-        cur_state = WorkPausedState(tomato=tomato)
+        cur_state = WorkPausedState(tomato)
         cur_state._prev = state
         return cur_state
 
@@ -326,8 +326,8 @@ class WorkPausedState(InitialState):
 class SmallBreakState(InitialState):
     name = "small break"
 
-    def __init__(self, tomato=None):
-        super().__init__(tomato=tomato)
+    def __init__(self, tomato):
+        super().__init__(tomato)
         self._remainder =
             self._tomato.configs.small_break_minutes)
         self._task = Tasks.SMALL_BREAK
@@ -345,7 +345,7 @@ class SmallBreakState(InitialState):
 
     @property
     def next_state(self):
-        return IntermediateState.transition_to(WorkingState, tomato=self._tomato)
+        return IntermediateState.transition_to(WorkingState, self._tomato)
 
     def pause(self):
         return SmallBreakPausedState.return_to(self._tomato, self)
@@ -362,8 +362,8 @@ class SmallBreakState(InitialState):
 class SmallBreakPausedState(InitialState):
     name = "small break paused"
 
-    def __init__(self, time_period=0, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
+    def __init__(self, time_period=0, tomato):
+        super().__init__(time_period=time_period, tomato)
         self._task = Tasks.SMALL_BREAK
         self._status = TaskStatus.PAUSED
         self._prev = None
@@ -378,7 +378,7 @@ class SmallBreakPausedState(InitialState):
 
     @staticmethod
     def return_to(tomato, state):
-        cur_state = SmallBreakPausedState(tomato=tomato)
+        cur_state = SmallBreakPausedState(tomato)
         cur_state._prev = state
         return cur_state
 
@@ -394,8 +394,8 @@ class SmallBreakPausedState(InitialState):
 class LongBreakState(SmallBreakState):
     name = "long break"
 
-    def __init__(self,tomato=None):
-        super().__init__(tomato=tomato)
+    def __init__(self,tomato):
+        super().__init__(tomato)
         self._task = Tasks.LONG_BREAK
         self._status = TaskStatus.STARTED
 
@@ -406,14 +406,14 @@ class LongBreakState(SmallBreakState):
 class LongBreakPausedState(SmallBreakPausedState):
     name = "long break paused"
 
-    def __init__(self, time_period=0, tomato=None):
-        super().__init__(time_period=time_period, tomato=tomato)
+    def __init__(self, tomato):
+        super().__init__(tomato)
         self._task = Tasks.LONG_BREAK
         self._status = TaskStatus.PAUSED
 
     @staticmethod
     def return_to(tomato, state):
-        cur_state = LongBreakPausedState(tomato=tomato)
+        cur_state = LongBreakPausedState(tomato)
         cur_state._prev = state
         return cur_state
 
@@ -422,7 +422,7 @@ class Tomato:
     def __init__(self, configs=config.Configuration()):
         # Load configurations from command line and .ini file
         self.configs = configs
-        self._state = InitialState(tomato=self)
+        self._state = InitialState(self)
         self.tomatoes = 0
 
     def start(self):
@@ -435,7 +435,7 @@ class Tomato:
         self._state = self._state.reset()
 
     def reset_all(self):
-        self._state = InitialState(tomato=self)
+        self._state = InitialState(self)
         self.tomatoes = 0
 
     def update(self):

--- a/pydoro/pydoro_core/tomato.py
+++ b/pydoro/pydoro_core/tomato.py
@@ -5,7 +5,7 @@ from timeit import default_timer
 
 from pydoro.pydoro_core import sound
 from pydoro.pydoro_core.util import in_app_path
-from pydoro.pydoro_core.configs import Configuration
+from pydoro.pydoro_core.config import Configuration
 
 SECONDS_PER_MIN = 60
 
@@ -156,7 +156,6 @@ class InitialState:
 
     def __init__(self, tomato):
         self._tomato = tomato
-        self._time_period = int(time_period) # TODO: use time period from tomato configs
         self._task = Tasks.NO_TASK
         self._status = TaskStatus.NONE
         self._started_at = 0
@@ -183,7 +182,7 @@ class InitialState:
 
     @property
     def time_period(self):
-        return self._time_period
+        return 0
 
     @property
     def time_remaining(self):
@@ -256,7 +255,7 @@ class WorkingState(InitialState):
 
     def __init__(self, tomato):
         super().__init__(tomato)
-        self._remainder =
+        self._remainder = \
             int(self._tomato.configs.work_minutes)
         self._task = Tasks.WORK
         self._status = TaskStatus.STARTED
@@ -328,8 +327,8 @@ class SmallBreakState(InitialState):
 
     def __init__(self, tomato):
         super().__init__(tomato)
-        self._remainder =
-            self._tomato.configs.small_break_minutes)
+        self._remainder = \
+            int(self._tomato.configs.small_break_minutes)
         self._task = Tasks.SMALL_BREAK
         self._status = TaskStatus.STARTED
         self._started_at = cur_time()
@@ -362,8 +361,8 @@ class SmallBreakState(InitialState):
 class SmallBreakPausedState(InitialState):
     name = "small break paused"
 
-    def __init__(self, time_period=0, tomato):
-        super().__init__(time_period=time_period, tomato)
+    def __init__(self, tomato):
+        super().__init__(tomato)
         self._task = Tasks.SMALL_BREAK
         self._status = TaskStatus.PAUSED
         self._prev = None
@@ -419,7 +418,7 @@ class LongBreakPausedState(SmallBreakPausedState):
 
 
 class Tomato:
-    def __init__(self, configs=config.Configuration()):
+    def __init__(self, configs=Configuration()):
         # Load configurations from command line and .ini file
         self.configs = configs
         self._state = InitialState(self)

--- a/pydoro/pydoro_core/tomato.py
+++ b/pydoro/pydoro_core/tomato.py
@@ -5,14 +5,8 @@ from timeit import default_timer
 
 from pydoro.pydoro_core import sound
 from pydoro.pydoro_core.util import in_app_path
-import configs
+from pydoro.pydoro_core.configs import Configuration
 
-TOMATOES_PER_SET = 4
-SECONDS_PER_MIN = 60
-WORK_TIME = 25 * SECONDS_PER_MIN
-SMALL_BREAK_TIME = 5 * SECONDS_PER_MIN
-LONG_BREAK_TIME = 15 * SECONDS_PER_MIN
-ALARM_TIME = 20
 
 PLACEHOLDER_TIME = "time"
 PLACEHOLDER_STATUS = "status"


### PR DESCRIPTION
This should make easy to set up configurations from the `.ini` file as well as to add new keybindings (#3).

Here are the original ideas for the refactor (taken from #49):
1. Refactor move config related content to a config module.
2. Create a new config class.
3. Have the values in the class filled up on its `__init__`.
4. Inject a config object to `Tomato` (using constructor).
5. This config object should also be used by all State classes to identify time chunk length.
6. Create tomato object after parsing arguments. `(TOMATO = None, then use global TOMATO; TOMATO = Tomato(config)`


Fixes #15 and #3 