### PR TITLE
add if condition to ask for _MEIPASS, else set os.path.dirname

### DIFF
--- a/pydoro/pydoro_core/util.py
+++ b/pydoro/pydoro_core/util.py
@@ -14,11 +14,13 @@ def every(delay, task):
 
 def in_app_path(path):
     try:
-        wd = sys._MEIPASS
+        if hasattr(sys, '_MEIPASS'):
+            wd = sys._MEIPASS
+        else:
+            wd = os.path.dirname(__file__)
         return os.path.abspath(os.path.join(wd, path))
     except AttributeError:
         return _from_resource(path)
-
 
 def _from_resource(path):
     from pkg_resources import resource_filename


### PR DESCRIPTION
i had the same problem like the people from this issue:

https://github.com/JaDogg/pydoro/issues/344

I added a condition which only sets _MEIPASS if it available. Otherwise it sets the path from where util.py is executed.

