### PR TITLE
fix: replace pkg_resources with importlib.resources for Python 3.12+ (closes #359)

### DIFF
--- a/pydoro/pydoro_core/util.py
+++ b/pydoro/pydoro_core/util.py
@@ -23,9 +23,15 @@ def in_app_path(path):
         return _from_resource(path)
 
 def _from_resource(path):
-    from pkg_resources import resource_filename
-
-    res_path = resource_filename(__name__, path)
+    try:
+        from importlib.resources import files
+        res_path = str(files(__package__).joinpath(path))
+    except (ImportError, TypeError):
+        try:
+            from pkg_resources import resource_filename
+            res_path = resource_filename(__name__, path)
+        except ImportError:
+            res_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
     if not os.path.exists(res_path):
         res_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
     return res_path


### PR DESCRIPTION
## Summary

Fixes #359 — pydoro fails to start on Python 3.13 with `ModuleNotFoundError: No module named 'pkg_resources'`.

### Problem
`pkg_resources` (from `setuptools`) is no longer bundled with Python 3.12+. When pydoro tries to resolve resource paths via `_from_resource()`, it fails on fresh Python 3.13 installs that don't have `setuptools`.

### Fix
Updated `_from_resource()` in `pydoro_core/util.py` to use a cascading fallback:

1. **`importlib.resources.files()`** (Python 3.9+, stdlib) — primary
2. **`pkg_resources.resource_filename()`** — fallback for older environments  
3. **`__file__`-relative path** — final fallback

This maintains backward compatibility while fixing the crash on modern Python.